### PR TITLE
add roles for confluent platform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -76,9 +76,9 @@ resource "aws_security_group" "broker" {
   }
 }
 
-resource "aws_security_group" "connect" {
+resource "aws_security_group" "connect_distributed" {
   description = "Connect security group - Managed by Terraform"
-  name = "${var.cluster_name}-${var.owner}-connect-security-group"
+  name = "${var.cluster_name}-${var.owner}-connect_distributed-security-group"
   vpc_id = "${var.vpc_id}"
   # connect http interface - only accessable on host, without this
   # c3 needs access
@@ -98,11 +98,11 @@ resource "aws_security_group" "connect" {
   }
 }
 
-resource "aws_security_group" "schema-registry" {
+resource "aws_security_group" "schema_registry" {
   description = "Schema Registry security group - Managed by Terraform"
-  name = "${var.cluster_name}-${var.owner}-schema-registry-security-group"
+  name = "${var.cluster_name}-${var.owner}-schema_registry-security-group"
   vpc_id = "${var.vpc_id}"
-  # schema-registry http interface - only accessable on host, without this
+  # schema_registry http interface - only accessable on host, without this
   # c3 needs access
   ingress {
       from_port = 8081
@@ -120,11 +120,11 @@ resource "aws_security_group" "schema-registry" {
   }
 }
 
-resource "aws_security_group" "control-center" {
+resource "aws_security_group" "control_center" {
   description = "Control Center security group - Managed by Terraform"
-  name = "${var.cluster_name}-${var.owner}-control-center"
+  name = "${var.cluster_name}-${var.owner}-control_center"
   vpc_id = "${var.vpc_id}"
-  # control-center http interface - only accessable on host, without this
+  # control_center http interface - only accessable on host, without this
   # c3 needs access
   ingress {
       from_port = 9021
@@ -142,7 +142,72 @@ resource "aws_security_group" "control-center" {
   }
 }
 
+resource "aws_security_group" "kafka_rest" {
+  description = "Kafka REST security group - Managed by Terraform"
+  name = "${var.cluster_name}-${var.owner}-kafka_rest"
+  vpc_id = "${var.vpc_id}"
+  # kafka REST http interface 
+  ingress {
+      from_port = 8082
+      to_port = 8082
+      protocol = "TCP"
+      self = true
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ksql" {
+  description = "KSQL server security group - Managed by Terraform"
+  name = "${var.cluster_name}-${var.owner}-ksql"
+  vpc_id = "${var.vpc_id}"
+  # KSQL server interface
+  ingress {
+      from_port = 8088
+      to_port = 8088
+      protocol = "TCP"
+      self = true
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 # instances
+resource "aws_instance" "bastion" {
+  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  instance_type = "t2.medium"
+  associate_public_ip_address = "true"
+  subnet_id = "${var.subnet_id}"
+  key_name = "${var.ec2_public_key_name}"
+  availability_zone = "${var.availability_zone}"
+  vpc_security_group_ids = "${var.bastion_vpc_security_group_ids}"
+  security_groups = [
+    "${aws_security_group.ssh.id}",
+    "${aws_security_group.allow-all-vpc.id}",
+    "${var.bastion_vpc_security_group_ids}"
+  ]
+  root_block_device {
+    delete_on_termination = "${var.bastion_delete_root_block_device_on_termination}"
+  }
+
+  tags ="${merge(
+    map("Name", "confluent-platform-bastion"),
+    local.common_tags,
+    )}" 
+}
+
 resource "aws_instance" "broker" {
   count = "${var.broker_count}"
   ami = "${lookup(var.aws_amis, var.aws_region)}"
@@ -153,7 +218,6 @@ resource "aws_instance" "broker" {
   availability_zone = "${var.availability_zone}"
   vpc_security_group_ids = "${var.broker_vpc_security_group_ids}"
   security_groups = [
-    "${aws_security_group.broker.id}",
     "${aws_security_group.ssh.id}",
     "${aws_security_group.broker.id}",
     "${aws_security_group.allow-all-vpc.id}",
@@ -170,32 +234,138 @@ resource "aws_instance" "broker" {
     )}"
 }
 
-resource "aws_instance" "worker" {
-  count = "${var.worker_count}"
+resource "aws_instance" "schema_registry" {
+  count = "${var.schema_registry_count}"
   ami = "${lookup(var.aws_amis, var.aws_region)}"
-  instance_type = "${var.worker_instance_type}"
-  associate_public_ip_address = "${var.worker_associate_public_ip_address}"
+  instance_type = "${var.schema_registry_instance_type}"
+  associate_public_ip_address = "${var.schema_registry_associate_public_ip_address}"
   subnet_id = "${var.subnet_id}"
   key_name = "${var.ec2_public_key_name}"
   availability_zone = "${var.availability_zone}"
-  vpc_security_group_ids = "${var.worker_vpc_security_group_ids}"
+  vpc_security_group_ids = "${var.schema_registry_vpc_security_group_ids}"
   security_groups = [
     "${aws_security_group.ssh.id}",
-    "${aws_security_group.schema-registry.id}",
-    "${aws_security_group.connect.id}",
-    "${aws_security_group.control-center.id}",
+    "${aws_security_group.schema_registry.id}",
     "${aws_security_group.allow-all-vpc.id}",
-    "${var.worker_vpc_security_group_ids}"
+    "${var.schema_registry_vpc_security_group_ids}"
   ]
 
   root_block_device {
-    delete_on_termination = "${var.worker_delete_root_block_device_on_termination}"
+    delete_on_termination = "${var.schema_registry_delete_root_block_device_on_termination}"
   }
 
   tags ="${merge(
-    map("Name", "confluent-platform-worker-node"),
+    map("Name", "confluent-platform-schema_registry-node"),
     local.common_tags,
-    var.worker_tags
+    var.schema_registry_tags
+    )}"
+}
+
+resource "aws_instance" "control_center" {
+  count = "${var.control_center_count}"
+  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  instance_type = "${var.control_center_instance_type}"
+  associate_public_ip_address = "${var.control_center_associate_public_ip_address}"
+  subnet_id = "${var.subnet_id}"
+  key_name = "${var.ec2_public_key_name}"
+  availability_zone = "${var.availability_zone}"
+  vpc_security_group_ids = "${var.control_center_vpc_security_group_ids}"
+  security_groups = [
+    "${aws_security_group.ssh.id}",
+    "${aws_security_group.control_center.id}",
+    "${aws_security_group.allow-all-vpc.id}",
+    "${var.control_center_vpc_security_group_ids}"
+  ]
+
+  root_block_device {
+    delete_on_termination = "${var.control_center_delete_root_block_device_on_termination}"
+  }
+
+  tags ="${merge(
+    map("Name", "confluent-platform-control_center-node"),
+    local.common_tags,
+    var.control_center_tags
+    )}"
+}
+
+resource "aws_instance" "connect_distributed" {
+  count = "${var.connect_distributed_count}"
+  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  instance_type = "${var.connect_distributed_instance_type}"
+  associate_public_ip_address = "${var.connect_distributed_associate_public_ip_address}"
+  subnet_id = "${var.subnet_id}"
+  key_name = "${var.ec2_public_key_name}"
+  availability_zone = "${var.availability_zone}"
+  vpc_security_group_ids = "${var.connect_distributed_vpc_security_group_ids}"
+  security_groups = [
+    "${aws_security_group.ssh.id}",
+    "${aws_security_group.connect_distributed.id}",
+    "${aws_security_group.allow-all-vpc.id}",
+    "${var.connect_distributed_vpc_security_group_ids}"
+  ]
+
+  root_block_device {
+    delete_on_termination = "${var.connect_distributed_delete_root_block_device_on_termination}"
+  }
+
+  tags ="${merge(
+    map("Name", "confluent-platform-connect_distributed-node"),
+    local.common_tags,
+    var.connect_distributed_tags
+    )}"
+}
+
+resource "aws_instance" "kafka_rest" {
+  count = "${var.kafka_rest_count}"
+  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  instance_type = "${var.kafka_rest_instance_type}"
+  associate_public_ip_address = "${var.kafka_rest_associate_public_ip_address}"
+  subnet_id = "${var.subnet_id}"
+  key_name = "${var.ec2_public_key_name}"
+  availability_zone = "${var.availability_zone}"
+  vpc_security_group_ids = "${var.kafka_rest_vpc_security_group_ids}"
+  security_groups = [
+    "${aws_security_group.ssh.id}",
+    "${aws_security_group.kafka_rest.id}",
+    "${aws_security_group.allow-all-vpc.id}",
+    "${var.kafka_rest_vpc_security_group_ids}"
+  ]
+
+  root_block_device {
+    delete_on_termination = "${var.kafka_rest_delete_root_block_device_on_termination}"
+  }
+
+  tags ="${merge(
+    map("Name", "confluent-platform-kafka_rest-node"),
+    local.common_tags,
+    var.kafka_rest_tags
+    )}"
+}
+
+resource "aws_instance" "ksql" {
+  count = "${var.ksql_count}"
+  ami = "${lookup(var.aws_amis, var.aws_region)}"
+  instance_type = "${var.ksql_instance_type}"
+  associate_public_ip_address = "${var.ksql_associate_public_ip_address}"
+  subnet_id = "${var.subnet_id}"
+  key_name = "${var.ec2_public_key_name}"
+  availability_zone = "${var.availability_zone}"
+  vpc_security_group_ids = "${var.ksql_vpc_security_group_ids}"
+  security_groups = [
+    "${aws_security_group.ssh.id}",
+    "${aws_security_group.ksql.id}",
+    "${aws_security_group.allow-all-vpc.id}",
+    "${var.ksql_vpc_security_group_ids}"
+  ]
+
+  root_block_device {
+    delete_on_termination = "${var.ksql_delete_root_block_device_on_termination}"
+  }
+
+  tags ="${merge(
+    map("Name", "confluent-platform-ksql-node"),
+    local.common_tags,
+    var.ksql_tags
     )}"
 }
 
@@ -212,6 +382,11 @@ resource "aws_volume_attachment" "broker_volume" {
   instance_id = "${element(aws_instance.broker.*.id, count.index)}"
 }
 
+output "bastion_public_dns" {
+  description = "Public DNS for bastion"
+  value = "${aws_instance.bastion.*.public_dns}"
+}
+
 output "broker_public_dns" {
   description = "Public DNS for Brokers"
   value = "${aws_instance.broker.*.public_dns}"
@@ -222,12 +397,52 @@ output "broker_private_dns" {
   value = "${aws_instance.broker.*.private_dns}"
 }
 
-output "worker_public_dns" {
-  description = "Public DNS for Workers"
-  value = "${aws_instance.worker.*.public_dns}"
+output "schema_registry_public_dns" {
+  description = "Public DNS for Schema Registry"
+  value = "${aws_instance.schema_registry.*.public_dns}"
 }
 
-output "worker_private_dns" {
-  description = "Private DNS for Workers"
-  value = "${aws_instance.worker.*.private_dns}"
+output "schema_registry_private_dns" {
+  description = "Private DNS for Schema Registry"
+  value = "${aws_instance.schema_registry.*.private_dns}"
+}
+
+output "control_center_public_dns" {
+  description = "Public DNS for Control Center"
+  value = "${aws_instance.control_center.*.public_dns}"
+}
+
+output "control_center_private_dns" {
+  description = "Private DNS for Control Center"
+  value = "${aws_instance.control_center.*.private_dns}"
+}
+
+output "connect_distributed_public_dns" {
+  description = "Public DNS for Connect Distributed"
+  value = "${aws_instance.connect_distributed.*.public_dns}"
+}
+
+output "connect_distributed_private_dns" {
+  description = "Private DNS for Connect Distributed"
+  value = "${aws_instance.connect_distributed.*.private_dns}"
+}
+
+output "kafka_rest_public_dns" {
+  description = "Public DNS for Kafka REST"
+  value = "${aws_instance.kafka_rest.*.public_dns}"
+}
+
+output "kafka_rest_private_dns" {
+  description = "Private DNS for Kafka REST"
+  value = "${aws_instance.kafka_rest.*.private_dns}"
+}
+
+output "ksql_public_dns" {
+  description = "Public DNS for KSQL Server"
+  value = "${aws_instance.ksql.*.public_dns}"
+}
+
+output "ksql_private_dns" {
+  description = "Private DNS for KSQL Server"
+  value = "${aws_instance.ksql.*.private_dns}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,34 @@
-variable "aws_access_key" {}
-variable "aws_access_key_secret" {}
+variable "owner" {
+  default = "myowner"
+}
 
-variable "aws_region" {}
+variable "aws_access_key" {
+  default = "my_access_key"
+}
 
-variable "availability_zone" {}
+variable "aws_access_key_secret" {
+  default = "my_access_key_secret"
+}
 
-variable "subnet_id" {}
+variable "aws_region" {
+  default = "us-east-2"
+}
 
-variable "vpc_id" {}
+variable "availability_zone" {
+  default = "us-east-2b"
+}
+
+variable "subnet_id" {
+  default = "subnet-a71c12df"
+}
+
+variable "vpc_id" {
+  default = "vpc-0be80162"
+}
+
+variable "ec2_public_key_name" {
+  default = "my_public_key"
+}
 
 variable "aws_amis" {
   default = {
@@ -33,7 +54,14 @@ variable "cluster_name" {
   default = "Confluent-Platform-Cluster"
 }
 
-variable "owner" {}
+# Bastion variables
+variable "bastion_vpc_security_group_ids" {
+  default = []
+}
+
+variable "bastion_delete_root_block_device_on_termination" {
+  default = true
+} 
 
 # Broker variables
 variable "broker_count" {
@@ -73,30 +101,133 @@ variable "broker_kafka_data_dir" {
   default = "/var/lib/kafka"
 }
 
-# Worker variables
-variable "worker_count" {
-  default = "2"
+#Schema Registry variables
+variable "schema_registry_count" {
+  default = "1"
 }
 
-variable "worker_instance_type" {
+variable "schema_registry_instance_type" {
   default = "t2.xlarge"
 }
 
-variable "ec2_public_key_name" {}
-
-variable "worker_vpc_security_group_ids" {
+variable "schema_registry_vpc_security_group_ids" {
   default = []
 }
 
-variable "worker_tags" {
+variable "schema_registry_associate_public_ip_address" {
+  default = true
+}
+
+variable "schema_registry_delete_root_block_device_on_termination" {
+  default = true
+}
+
+variable "schema_registry_tags" {
   type = "map"
   default = {}
 }
 
-variable "worker_associate_public_ip_address" {
+#Control Center Variables
+variable "control_center_count" {
+  default = "1"
+}
+
+variable "control_center_instance_type" {
+  default = "t2.xlarge"
+}
+
+variable "control_center_vpc_security_group_ids" {
+  default = []
+}
+
+variable "control_center_associate_public_ip_address" {
   default = true
 }
 
-variable "worker_delete_root_block_device_on_termination" {
+variable "control_center_delete_root_block_device_on_termination" {
   default = true
 }
+
+variable "control_center_tags" {
+  type = "map"
+  default = {}
+}
+
+#Connect Distributed Variables
+variable "connect_distributed_count" {
+  default = "0"
+}
+
+variable "connect_distributed_instance_type" {
+  default = "t2.xlarge"
+}
+
+variable "connect_distributed_vpc_security_group_ids" {
+  default = []
+}
+
+variable "connect_distributed_associate_public_ip_address" {
+  default = true
+}
+
+variable "connect_distributed_delete_root_block_device_on_termination" {
+  default = true
+}
+
+variable "connect_distributed_tags" {
+  type = "map"
+  default = {}
+}
+
+#Kafka REST Variables
+variable "kafka_rest_count" {
+  default = "0"
+}
+
+variable "kafka_rest_instance_type" {
+  default = "t2.xlarge"
+}
+
+variable "kafka_rest_vpc_security_group_ids" {
+  default = []
+}
+
+variable "kafka_rest_associate_public_ip_address" {
+  default = true
+}
+
+variable "kafka_rest_delete_root_block_device_on_termination" {
+  default = true
+}
+
+variable "kafka_rest_tags" {
+  type = "map"
+  default = {}
+}
+
+#KSQL Server Variables
+variable "ksql_count" {
+  default = "0"
+}
+
+variable "ksql_instance_type" {
+  default = "t2.xlarge"
+}
+
+variable "ksql_vpc_security_group_ids" {
+  default = []
+}
+
+variable "ksql_associate_public_ip_address" {
+  default = true
+}
+
+variable "ksql_delete_root_block_device_on_termination" {
+  default = true
+}
+
+variable "ksql_tags" {
+  type = "map"
+  default = {}
+}
+


### PR DESCRIPTION
@cjmatta this PR breaks out the roles for confluent platform for a tighter integration with cp-ansible. You can specify counts per role. There's more to be done here in terms of instance sizing for sure.