### PR TITLE
Added new variable 'prefix' to make instance naming more distinct

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Can be used with Confluent's Ansible: http://github.com/confluentinc/cp-ansible
 |Property | Documentation| Default | Required? |
 | ------- | ------------ | ------- | --------- |
 | owner   | tag describing the owner, will be used in cluster name | | yes |
+| prefix   | prefix used in naming instances | confluent-platform | no |
 | aws_access_key | the access key for your AWS account | | yes |
 | aws_access_key_secret | the access key secret for your AWS account | | yes |
 | aws_region | AWS region | | yes |

--- a/create_ansible_inventory.py
+++ b/create_ansible_inventory.py
@@ -3,6 +3,7 @@
 # output of `https://github.com/cjmatta/cp-poc-terraform
 # Usage: terraform output -json` | ./create_ansible_inventory.py
 import json
+import argparse
 from jinja2 import Template
 import sys
 
@@ -14,23 +15,23 @@ template = Template("""all:
     security_mode: sasl_ssl
 preflight:
   hosts:
-{%- for broker in broker_public_dns.value %}
+{%- for broker in broker_dns.value %}
     {{broker}}:
 {%- endfor %}
-{%- for worker in worker_public_dns.value %}
+{%- for worker in worker_dns.value %}
     {{worker}}:
 {%- endfor %}
 ssl_CA:
   hosts:
-    {{broker_public_dns.value[0]}}:
+    {{broker_dns.value[0]}}:
 zookeeper:
   hosts:
-{%- for broker in broker_public_dns.value %}
+{%- for broker in broker_dns.value %}
     {{broker}}:
 {%- endfor %}
 broker:
   hosts:
-{%- for broker in broker_public_dns.value %}
+{%- for broker in broker_dns.value %}
     {{broker}}:
       kafka:
         broker:
@@ -38,38 +39,38 @@ broker:
 {%- endfor %}
 schema-registry:
   hosts:
-{%- for worker in worker_public_dns.value %}
+{%- for worker in worker_dns.value %}
     {{worker}}:
 {%- endfor %}
 control-center:
   hosts:
-    {{worker_public_dns.value[0]}}:
+    {{worker_dns.value[0]}}:
       confluent:
         control:
           center:
             config:
-              confluent.controlcenter.connect.cluster: {% for worker in worker_public_dns.value -%}
+              confluent.controlcenter.connect.cluster: {% for worker in worker_dns.value -%}
                 {{worker}}:8083
                 {%- if not loop.last %},{% endif %}
                 {%- endfor %}
 connect-distributed:
   hosts:
-{%- for worker in worker_public_dns.value %}
+{%- for worker in worker_dns.value %}
     {{worker}}:
 {%- endfor %}
 kafka-rest:
   hosts:
-{%- for worker in worker_public_dns.value %}
+{%- for worker in worker_dns.value %}
     {{worker}}:
 {%- endfor %}
 ksql:
   hosts:
-{%- for worker in worker_public_dns.value %}
+{%- for worker in worker_dns.value %}
     {{worker}}:
 {%- endfor %}
 tools:
   hosts:
-    {{worker_public_dns.value[0]}}:""")
+    {{worker_dns.value[0]}}:""")
 
 def read_stdin_json():
     try:
@@ -80,4 +81,19 @@ def read_stdin_json():
         sys.exit(1)
 
 input = read_stdin_json()
-print(template.render(input))
+
+# construct the argument parser and parse the arguments
+ap = argparse.ArgumentParser()
+ap.add_argument("-p", "--public", action="store_true",
+	help="Use public DNS from terraform, default is private")
+args = ap.parse_args()
+
+if args.public:
+    dns_type = 'public'
+else:
+    dns_type = 'private'
+template_params = {
+    "worker_dns": input['worker_'+dns_type+'_dns'], 
+    "broker_dns": input['broker_'+dns_type+'_dns']
+}
+print(template.render(template_params))

--- a/create_ansible_inventory.py
+++ b/create_ansible_inventory.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# This script is meant to be used in conjunction with the JSON formatted
+# output of `https://github.com/cjmatta/cp-poc-terraform
+# Usage: terraform output -json` | ./create_ansible_inventory.py
+import json
+from jinja2 import Template
+import sys
+
+template = Template("""all:
+  vars:
+    ansible_connection: ssh
+    ansible_ssh_user: centos
+    ansible_become: true
+    security_mode: sasl_ssl
+preflight:
+  hosts:
+{%- for broker in broker_public_dns.value %}
+    {{broker}}:
+{%- endfor %}
+{%- for worker in worker_public_dns.value %}
+    {{worker}}:
+{%- endfor %}
+ssl_CA:
+  hosts:
+    {{broker_public_dns.value[0]}}:
+zookeeper:
+  hosts:
+{%- for broker in broker_public_dns.value %}
+    {{broker}}:
+{%- endfor %}
+broker:
+  hosts:
+{%- for broker in broker_public_dns.value %}
+    {{broker}}:
+      kafka:
+        broker:
+          id: {{loop.index}}
+{%- endfor %}
+schema-registry:
+  hosts:
+{%- for worker in worker_public_dns.value %}
+    {{worker}}:
+{%- endfor %}
+control-center:
+  hosts:
+    {{worker_public_dns.value[0]}}:
+      confluent:
+        control:
+          center:
+            config:
+              confluent.controlcenter.connect.cluster: {% for worker in worker_public_dns.value -%}
+                {{worker}}:8083
+                {%- if not loop.last %},{% endif %}
+                {%- endfor %}
+connect-distributed:
+  hosts:
+{%- for worker in worker_public_dns.value %}
+    {{worker}}:
+{%- endfor %}
+kafka-rest:
+  hosts:
+{%- for worker in worker_public_dns.value %}
+    {{worker}}:
+{%- endfor %}
+ksql:
+  hosts:
+{%- for worker in worker_public_dns.value %}
+    {{worker}}:
+{%- endfor %}
+tools:
+  hosts:
+    {{worker_public_dns.value[0]}}:""")
+
+def read_stdin_json():
+    try:
+        input_json = json.loads(sys.stdin.read())
+        return input_json
+    except ValueError, e:
+        print "Error: STDIN is not JSON"
+        sys.exit(1)
+
+input = read_stdin_json()
+print(template.render(input))

--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ resource "aws_instance" "broker" {
   }
 
   tags ="${merge(
-    map("Name", "confluent-platform-kafka-broker"),
+    map("Name", "${var.prefix}-kafka-broker"),
     local.common_tags,
     var.broker_tags
     )}"
@@ -143,7 +143,7 @@ resource "aws_instance" "worker" {
   }
 
   tags ="${merge(
-    map("Name", "confluent-platform-worker-node"),
+    map("Name", "${var.prefix}-worker-node"),
     local.common_tags,
     var.worker_tags
     )}"

--- a/register_host_keys.py
+++ b/register_host_keys.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# This script is meant to be used in conjunction with the JSON formatted
+# output of `https://github.com/cjmatta/cp-poc-terraform
+# Usage: terraform output -json` | ./register_host_keys.py
+import json
+import sys
+import subprocess
+
+def read_stdin_json():
+    try:
+        input_json = json.loads(sys.stdin.read())
+        return input_json
+    except ValueError, e:
+        print "Error: STDIN is not JSON"
+        sys.exit(1)
+
+input = read_stdin_json()
+for broker in input['broker_public_dns']['value']:
+    s = ['ssh-keyscan  -t ecdsa ', broker, ' >> ~/.ssh/known_hosts']
+    subprocess.call("ssh-keyscan  -t ecdsa %s >> ~/.ssh/known_hosts" % broker, shell=True)
+for worker in input['worker_public_dns']['value']:
+    s = ['ssh-keyscan  -t ecdsa ', worker, ' >> ~/.ssh/known_hosts']
+    subprocess.call("ssh-keyscan  -t ecdsa %s >> ~/.ssh/known_hosts" % worker, shell=True)

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,10 @@ variable "cluster_name" {
 
 variable "owner" {}
 
+variable "prefix" {
+	default = "confluent-platform"
+}
+
 # Broker variables
 variable "broker_count" {
   default = "3"


### PR DESCRIPTION
If multiple people use these terraform scripts to spin up instances in a shared AWS account they will all have the same name.

This adds a variable "prefix" that will be used when creating instance names so that they can be easily told apart. Defaults to using the current value "confluent-platform".